### PR TITLE
Apply policy for @atomist/automation-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "@atomist/automation-client": "^1.5.3",
+    "@atomist/automation-client": "^1.6.0",
     "@atomist/sdm": "^1.6.0",
     "@atomist/sdm-core": "^1.6.1",
     "@atomist/sdm-pack-analysis": "1.1.0-master.20190526073852",


### PR DESCRIPTION
Apply policy `npm-project-deps::atomist::automation-client`:

**New NPM Package Target**
Target version for NPM package *@atomist/automation-client* is `^1.6.0`.
Project *sdm-org/samples/master* is currently configured to use version `^1.5.3`.

_NPM dependencies_
```@atomist/automation-client (^1.6.0)```

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::atomist::automation-client=1842b60a85adc9f0147b6b0cf372795ebb5b0e9881e862c78e8a0ba9e7880924]</code>
</details>