### PR TITLE
Apply policy for @atomist/automation-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   ],
   "main": "./index.js",
   "types": "./index.d.ts",
-  "dependencies": { 
-    "@atomist/automation-client": "^1.1.1",
+  "dependencies": {
+    "@atomist/automation-client": "^1.1.3",
     "@atomist/sdm": "^1.6.0",
     "@atomist/sdm-core": "^1.6.1",
     "@atomist/sdm-pack-analysis": "1.1.0-master.20190526073852",


### PR DESCRIPTION
Apply policy `npm-project-deps::atomist::automation-client`:

**New NPM Package Policy**
Policy version for NPM package *@atomist/automation-client* is `^1.1.3`.
Project *sdm-org/samples/master* is currently configured to use version `^1.1.1`.

_NPM dependencies_
```@atomist/automation-client (^1.1.3)```

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::atomist::automation-client=2219eb60a8c0be2ab235a52d29d432ee1d0677eafe94f9aff926c2cf19b0c4a2]</code>
</details>