### PR TITLE
Apply policy for @atomist/automation-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   ],
   "main": "./index.js",
   "types": "./index.d.ts",
-  "dependencies": { 
-    "@atomist/automation-client": "^1.1.2",
+  "dependencies": {
+    "@atomist/automation-client": "^1.6.2",
     "@atomist/sdm": "^1.6.0",
     "@atomist/sdm-core": "^1.6.1",
     "@atomist/sdm-pack-analysis": "1.1.0-master.20190526073852",


### PR DESCRIPTION
Apply policy `npm-project-deps::atomist::automation-client`:

**New NPM Package Policy**
Policy version for NPM package *@atomist/automation-client* is `^1.6.2`.
Project *sdm-org/samples/master* is currently configured to use version `^1.1.2`.

_NPM dependencies_
```@atomist/automation-client (^1.6.2)```

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::atomist::automation-client=87efccbdfd36903fd5d1f0d492c5f0d6a37287a0901717d24f21eaf7a75136fe]</code>
</details>